### PR TITLE
Use `vergen` to inject git SHA1 at buildtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "vergen",
 ]
 
 [[package]]
@@ -2032,6 +2033,16 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce50d8996df1f85af15f2cd8d33daae6e479575123ef4314a51a70a230739cb"
+dependencies = [
+ "bitflags",
+ "chrono",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "segelflug-classifieds"
 version = "0.0.0"
 authors = ["Tobias Bieniek <tobias@bieniek.cloud>"]
 edition = "2018"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -24,3 +25,6 @@ serde_urlencoded = "0.7.0"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.22"
 tracing-subscriber = "0.2.15"
+
+[build-dependencies]
+vergen = "3.1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+use vergen::{generate_cargo_keys, ConstantsFlags};
+
+fn main() {
+    generate_cargo_keys(ConstantsFlags::all()).expect("Unable to generate the cargo keys!");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,17 @@ struct Opts {
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
+    let sha = env!("VERGEN_SHA_SHORT");
+    debug!("running revision: {}", sha);
+
     let sentry_dsn = std::env::var("SENTRY_DSN");
-    let _guard = sentry_dsn.map(sentry::init);
+    let _guard = sentry_dsn.map(|dsn| {
+        let options = sentry::ClientOptions {
+            release: Some(sha.into()),
+            ..Default::default()
+        };
+        sentry::init((dsn, options))
+    });
 
     let opts: Opts = Opts::parse();
     trace!("opts = {:#?}", opts);


### PR DESCRIPTION
This makes it possible for Sentry issues to show which git commit they belong to.