### PR TITLE
clippy: Adjust CLI arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
       - uses: actions/checkout@v3.0.2
       - run: rustup component add clippy
       - uses: Swatinem/rust-cache@v1.4.0
-      - run: cargo clippy -- --deny warnings --allow clippy::unknown-clippy-lints
+      - run: cargo clippy -- --deny warnings --allow unknown_lints


### PR DESCRIPTION
```
warning: lint `clippy::unknown_clippy_lints` has been renamed to `unknown_lints`
  |
  = note: requested on the command line with `-A clippy::unknown_clippy_lints`
```