### PR TITLE
tracing: Add timestamps to log output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,6 @@ async fn main() -> Result<()> {
 
     let log_layer = tracing_subscriber::fmt::layer()
         .pretty()
-        .without_time()
         .with_filter(log_filter);
 
     let sentry_filter = filter::Targets::new().with_default(Level::INFO);


### PR DESCRIPTION
The deployment setup has changed to a system that does not show any timestamps by itself anymore, thus we're adding timestamps via `tracing` again.